### PR TITLE
refactor: improve vector.yaml transform for cleaner log data

### DIFF
--- a/vector.yaml
+++ b/vector.yaml
@@ -21,24 +21,30 @@ transforms:
     inputs: ["curio_logs"]
     source: |
       .client_id = "YOUR_CLIENT_ID"
+      .platform = "Curio PDP"
+
+      # Remove fields that reveal unneeded SP info.
       del(.source_type)
       del(.host)
       del(.file)
 
-      # Parse JSON from message field
+      # Parse JSON from message field and inline it
       parsed, err = parse_json(.message)
       if err == null {
         . = merge!(., parsed)
+        # Remove original message field since the fields have been inlined
+        del(.message)
       }
 
-      # Set dt from ts field or timestamp
-      if exists(.ts) {
-        .dt = .ts
-      } else {
+      # Set dt, which is required for BetterStack.
+      # Priority is given to .ts over .timestamp.
+      # They are then removed to avoid duplication/clutter.
+      if exists(.timestamp) {
         .dt = del(.timestamp)
       }
-
-      .platform = "Curio PDP"
+      if exists(.ts) {
+        .dt = del(.ts)
+      }
 
   version_parser:
     type: "remap"


### PR DESCRIPTION
## Summary

Optimizes the `curio_parser` transform in vector.yaml to send cleaner, more efficient data to Better Stack by eliminating duplicate fields and improving the transform logic.

## Changes

### Field Cleanup
- **Remove duplicate timestamp fields**: After setting `.dt`, both `.ts` and `.timestamp` are deleted using `del()` to avoid sending redundant timestamp data
- **Delete `.message` field**: After parsing and merging JSON content, the original `.message` field is removed since all fields have been inlined
- **Priority handling**: `.ts` takes priority over `.timestamp` when setting `.dt`

### Code Organization
- Move `.platform = "Curio PDP"` assignment to the top of the transform for consistency
- Reorganize timestamp handling logic for better clarity
- Improve comments to explain field handling and BetterStack requirements

## Benefits

- **Reduced data duplication**: Eliminates redundant fields, reducing storage costs
- **Better query performance**: Cleaner data structure makes queries faster and simpler
- **Improved maintainability**: Better organized code with clear comments

## Testing

After deployment, verify that logs in Better Stack:
- Have `.dt` field set correctly
- Do NOT have `.ts`, `.timestamp`, or `.message` fields
- Still contain all the parsed JSON fields from the original message

🤖 Generated with [Claude Code](https://claude.com/claude-code)